### PR TITLE
feat(markdown): .md 확장자 파일 인식 지원 (.mdx 폴백)

### DIFF
--- a/src/1-entities/markdown/util/get-frontmatter.test.ts
+++ b/src/1-entities/markdown/util/get-frontmatter.test.ts
@@ -249,6 +249,60 @@ describe('Unit 테스트 - 에러 케이스', () => {
 });
 
 // ============================================================================
+// Unit 테스트: .mdx → .md 폴백
+// ============================================================================
+
+describe('Unit 테스트 - .mdx → .md 폴백', () => {
+  it('.mdx 요청 실패 시 .md로 재시도해야 한다', async () => {
+    vi.mocked(api.get)
+      .mockResolvedValueOnce({
+        data: '',
+        axios: { status: 404 } as AxiosResponse<string>,
+      })
+      .mockResolvedValueOnce({
+        data: mockMDXFull,
+        axios: { status: 200 } as AxiosResponse,
+      });
+
+    const result = await getFrontmatter('2024/Post.mdx');
+
+    expect(api.get).toHaveBeenCalledTimes(2);
+    expect(api.get).toHaveBeenNthCalledWith(1, '2024/Post.mdx', {
+      baseURL: undefined,
+    });
+    expect(api.get).toHaveBeenNthCalledWith(2, '2024/Post.md', {
+      baseURL: undefined,
+    });
+    expect(result.title).toBe('테스트 포스트');
+  });
+
+  it('.mdx와 .md 모두 실패하면 에러를 던져야 한다', async () => {
+    vi.mocked(api.get).mockResolvedValue({
+      data: '',
+      axios: { status: 404 } as AxiosResponse<string>,
+    });
+
+    await expect(getFrontmatter('2024/Post.mdx')).rejects.toThrow(
+      'Failed to fetch markdown file'
+    );
+    expect(api.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('.md 경로는 폴백 없이 바로 에러를 던져야 한다', async () => {
+    vi.mocked(api.get).mockResolvedValue({
+      data: '',
+      axios: { status: 404 } as AxiosResponse<string>,
+    });
+
+    await expect(getFrontmatter('2024/Post.md')).rejects.toThrow(
+      'Failed to fetch markdown file'
+    );
+    // .md는 재시도 없이 1번만 호출됨
+    expect(api.get).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ============================================================================
 // Property-Based 테스트: 임의의 title/series 조합
 // ============================================================================
 

--- a/src/1-entities/markdown/util/get-frontmatter.ts
+++ b/src/1-entities/markdown/util/get-frontmatter.ts
@@ -23,7 +23,13 @@ export async function getFrontmatter(
     s.replaceAll('_', ' ')
   );
 
-  const response = await api.get<string>(realPath, { baseURL });
+  let response = await api.get<string>(realPath, { baseURL });
+
+  // .mdx 요청 실패 시 .md 확장자로 재시도
+  if (response.axios.status !== 200 && realPath.endsWith('.mdx')) {
+    const mdPath = realPath.replace(/\.mdx$/, '.md');
+    response = await api.get<string>(mdPath, { baseURL });
+  }
 
   if (response.axios.status !== 200) {
     throw new Error('Failed to fetch markdown file');

--- a/src/1-entities/markdown/util/get-markdown.test.ts
+++ b/src/1-entities/markdown/util/get-markdown.test.ts
@@ -317,6 +317,55 @@ describe('Unit 테스트 - 에러 케이스', () => {
     await expect(getMarkdown('error/Post.md')).rejects.toThrow('Network error');
   });
 
+  it('.mdx 요청 실패 시 .md로 재시도해야 한다', async () => {
+    vi.mocked(api.get)
+      .mockResolvedValueOnce({
+        data: '',
+        axios: { status: 404 } as AxiosResponse<string>,
+      })
+      .mockResolvedValueOnce({
+        data: mockMDX,
+        axios: { status: 200 } as AxiosResponse,
+      });
+
+    const result = await getMarkdown('test/Post.mdx');
+
+    // 검증: .mdx 실패 후 .md로 재시도
+    expect(api.get).toHaveBeenCalledTimes(2);
+    expect(api.get).toHaveBeenNthCalledWith(1, 'test/Post.mdx', {
+      baseURL: undefined,
+    });
+    expect(api.get).toHaveBeenNthCalledWith(2, 'test/Post.md', {
+      baseURL: undefined,
+    });
+    expect(result.frontmatter.title).toBe('Test Post');
+  });
+
+  it('.mdx와 .md 모두 실패하면 에러를 던져야 한다', async () => {
+    vi.mocked(api.get).mockResolvedValue({
+      data: '',
+      axios: { status: 404 } as AxiosResponse<string>,
+    });
+
+    await expect(getMarkdown('not-found/Post.mdx')).rejects.toThrow(
+      'Failed to fetch posts'
+    );
+    expect(api.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('.md 경로는 폴백 없이 바로 에러를 던져야 한다', async () => {
+    vi.mocked(api.get).mockResolvedValue({
+      data: '',
+      axios: { status: 404 } as AxiosResponse<string>,
+    });
+
+    await expect(getMarkdown('not-found/Post.md')).rejects.toThrow(
+      'Failed to fetch posts'
+    );
+    // .md는 재시도 없이 1번만 호출됨
+    expect(api.get).toHaveBeenCalledTimes(1);
+  });
+
   it('잘못된 MDX 문법은 evaluate 에러를 발생시켜야 한다', async () => {
     vi.mocked(api.get).mockResolvedValue({
       data: mockInvalidMDX,

--- a/src/1-entities/markdown/util/get-markdown.ts
+++ b/src/1-entities/markdown/util/get-markdown.ts
@@ -35,7 +35,13 @@ export default async function getMarkdown(
     s.replaceAll('_', ' ')
   );
 
-  const response = await api.get<string>(realPath, { baseURL });
+  let response = await api.get<string>(realPath, { baseURL });
+
+  // .mdx 요청 실패 시 .md 확장자로 재시도
+  if (response.axios.status !== 200 && realPath.endsWith('.mdx')) {
+    const mdPath = realPath.replace(/\.mdx$/, '.md');
+    response = await api.get<string>(mdPath, { baseURL });
+  }
 
   if (response.axios.status !== 200) {
     throw new Error('Failed to fetch posts');


### PR DESCRIPTION
## Summary

- `.mdx` 파일 fetch 실패 시 `.md` 확장자로 자동 재시도하는 폴백 로직 추가
- `get-frontmatter`, `get-markdown` 두 유틸리티 모두에 적용
- 두 확장자 모두 실패하면 기존과 동일하게 에러 throw

## Test plan

- [x] `.mdx` 요청 실패 시 `.md`로 재시도하는 테스트
- [x] `.mdx`와 `.md` 모두 실패 시 에러 throw 테스트
- [x] `.md` 경로는 폴백 없이 즉시 에러 throw 테스트 (불필요한 재시도 방지)
- [x] 기존 테스트 전체 통과 (38개)

🤖 Generated with [Claude Code](https://claude.com/claude-code)